### PR TITLE
chore: update composer.json to support Laravel 12 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+# 0.0.5
+
+- Suporte ao Laravel 12.
+
 # 0.0.4
+
 - Configurações: Permitir informar api_token.
 - Mensagens: Permitir que código cliente altere a versão da api. header: `api-version`.
 

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.8",
-        "illuminate/notifications": "~10.0 || ~11.0",
-        "illuminate/support": "~10.0 || ~11.0"
+        "illuminate/notifications": "~10.0 || ~11.0 || ~12.0",
+        "illuminate/support": "~10.0 || ~11.0 || ~12.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
This pull request updates the package to support Laravel 12, ensuring compatibility with the latest version of the framework. The most important changes are grouped below:

Laravel 12 compatibility:

* Updated the `composer.json` requirements for `illuminate/notifications` and `illuminate/support` to include version 12.0.
* Added a changelog entry for version 0.0.5 noting support for Laravel 12.