### PR TITLE
Verificação - gate do input de código pelo sinal do bot

### DIFF
--- a/src/VerificationClient.php
+++ b/src/VerificationClient.php
@@ -137,6 +137,27 @@ class VerificationClient
     }
 
     /**
+     * Check whether the bot signal for a number has already landed.
+     *
+     * Returns `pending: true` only once a live, non-expired code exists for the
+     * number — i.e. the OTP the bot generated finished propagating. A UI should
+     * keep the code input locked until this is true, so the end user never
+     * confirms during the propagation window and hits a spurious `not_found`.
+     *
+     * Read-only: it never expires a code nor consumes an attempt.
+     *
+     * @throws ZapmizerVerificationException
+     */
+    public function pending(string $number): VerificationStatus
+    {
+        $response = $this->request('POST', '/verify-number/pending', [
+            'json' => ['number' => $number],
+        ]);
+
+        return VerificationStatus::fromPayload($this->decode($response));
+    }
+
+    /**
      * Perform an authenticated request against the verify-number API.
      *
      * @throws ZapmizerVerificationException

--- a/src/VerificationStatus.php
+++ b/src/VerificationStatus.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace NotificationChannels\Zapmizer;
+
+/**
+ * Class VerificationStatus.
+ *
+ * Outcome of a pending() call: whether the bot signal for a number has already
+ * landed (a live, non-expired code exists) and how many seconds of TTL it has
+ * left. It is the gate a verification UI checks before unlocking the code input
+ * — while the code the bot generated is still propagating, `pending` is false,
+ * so the end user cannot confirm too early and hit the propagation race.
+ */
+final class VerificationStatus
+{
+    public function __construct(
+        public readonly bool $pending,
+        public readonly ?int $secondsLeft = null,
+        public readonly array $raw = [],
+    ) {
+    }
+
+    /**
+     * Build a VerificationStatus from a decoded API payload.
+     */
+    public static function fromPayload(array $payload): self
+    {
+        $data = $payload['data'] ?? $payload;
+
+        return new self(
+            pending: (bool) ($data['pending'] ?? false),
+            secondsLeft: isset($data['seconds_left']) ? (int) $data['seconds_left'] : null,
+            raw: $data,
+        );
+    }
+
+    public function isPending(): bool
+    {
+        return $this->pending;
+    }
+}

--- a/tests/Unit/VerificationClientTest.php
+++ b/tests/Unit/VerificationClientTest.php
@@ -16,6 +16,7 @@ use NotificationChannels\Zapmizer\Test\TestCase;
 use NotificationChannels\Zapmizer\VerificationClient;
 use NotificationChannels\Zapmizer\VerificationResult;
 use NotificationChannels\Zapmizer\VerificationSession;
+use NotificationChannels\Zapmizer\VerificationStatus;
 
 class VerificationClientTest extends TestCase
 {
@@ -137,6 +138,46 @@ class VerificationClientTest extends TestCase
 
         $this->assertTrue($result->isNotFound());
         $this->assertFalse($result->isVerified());
+    }
+
+    public function testPendingReportsTheSignalArrivedWithTtlLeft()
+    {
+        $client = $this->makeClient(new MockHandler([
+            new Response(200, [], json_encode([
+                'pending' => true,
+                'seconds_left' => 273,
+            ])),
+        ]));
+
+        $status = $client->pending('+55 11 99999-9999');
+
+        $this->assertInstanceOf(VerificationStatus::class, $status);
+        $this->assertTrue($status->isPending());
+        $this->assertEquals(273, $status->secondsLeft);
+
+        $request = $this->history[0]['request'];
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('http://localhost/api/verify-number/pending', (string) $request->getUri());
+        $this->assertEquals('Bearer team-api-token', $request->getHeaderLine('Authorization'));
+        $this->assertEquals(
+            ['number' => '+55 11 99999-9999'],
+            json_decode((string) $request->getBody(), true)
+        );
+    }
+
+    public function testPendingReportsNotReadyWhileTheSignalIsStillPropagating()
+    {
+        $client = $this->makeClient(new MockHandler([
+            new Response(200, [], json_encode([
+                'pending' => false,
+                'seconds_left' => null,
+            ])),
+        ]));
+
+        $status = $client->pending('5511999999999');
+
+        $this->assertFalse($status->isPending());
+        $this->assertNull($status->secondsLeft);
     }
 
     public function testNetworkFailureBecomesTypedException()


### PR DESCRIPTION
No primeiro passo do onboarding o usuário recebe o código no WhatsApp e digita antes dele terminar de propagar pro backend, então a confirmação responde `not_found` mesmo com o código certo em mãos ("ainda não recebemos sua mensagem"). Retry no cliente só mascara — o certo é gatear o input pelo sinal.

- Novo `pending()` no client: consulta read-only que diz se o sinal do bot já chegou pro número (código vivo, dentro do TTL), sem gastar tentativa nem expirar código.
- Resultado tipado em `VerificationStatus` (`pending` + `secondsLeft`), espelhando o `VerificationResult`.
- Permite à UI travar o input de código até o sinal chegar, eliminando a corrida na raiz em vez de contorná-la.